### PR TITLE
Fixed maven warnings about missing versions.

### DIFF
--- a/boundbox-library-integration-tests/pom.xml
+++ b/boundbox-library-integration-tests/pom.xml
@@ -63,6 +63,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build-helper-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -80,6 +81,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>

--- a/boundbox-library/dependency-reduced-pom.xml
+++ b/boundbox-library/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>boundbox-parent</artifactId>
     <groupId>org.boundbox</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>boundbox-library</artifactId>
@@ -56,10 +56,13 @@
         <executions>
           <execution>
             <id>filter-src</id>
-            <phase>process-sources</phase>
             <goals>
               <goal>filter-sources</goal>
             </goals>
+            <configuration>
+              <sourceDirectory>${basedir}/src/main/java-templates</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/java-templates</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -119,7 +122,7 @@
   </build>
   <profiles>
     <profile>
-      <id>silent</id>
+      <id>release</id>
       <properties>
         <log.level>Level.OFF</log.level>
       </properties>
@@ -187,6 +190,12 @@
       <artifactId>lombok</artifactId>
       <version>0.12.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>1.3.2</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/samples/boundbox-android-sample-tests/pom.xml
+++ b/samples/boundbox-android-sample-tests/pom.xml
@@ -78,6 +78,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build-helper-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -95,6 +96,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>

--- a/samples/boundbox-android-sample/pom.xml
+++ b/samples/boundbox-android-sample/pom.xml
@@ -58,6 +58,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>

--- a/samples/boundbox-sample/pom.xml
+++ b/samples/boundbox-sample/pom.xml
@@ -65,6 +65,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build-helper-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -82,6 +83,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>


### PR DESCRIPTION
Version properties existed in the poms, they just weren't used. Used them.

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.boundbox:boundbox-sample-integration-tests:jar:1.2.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 81, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 63, column 12
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.boundbox:boundbox-sample:jar:1.2.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 83, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 65, column 12
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.boundbox:boundbox-android-sample:apk:1.2.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 59, column 12
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.boundbox:boundbox-android-sample-tests:apk:1.2.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 96, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 78, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
